### PR TITLE
PR-3907: Fix the command do not execute twice

### DIFF
--- a/internal/workers/command_worker.go
+++ b/internal/workers/command_worker.go
@@ -31,10 +31,6 @@ func (a TeslaCommandArgs) InsertOpts() river.InsertOpts {
 		MaxAttempts: 3,                // Allow retries for command failures
 		Queue:       "tesla_commands", // Dedicated queue
 		Priority:    1,                // Normal priority
-		UniqueOpts: river.UniqueOpts{
-			ByArgs:  true, // Prevent duplicate commands
-			ByQueue: true, // Within the same queue
-		},
 	}
 }
 


### PR DESCRIPTION
- removed UniqueOpts constraints , as it is prevent the same command execute more than once per vehicle
